### PR TITLE
Fix the build when using python3 - print needs parentheses

### DIFF
--- a/rmtest/disposableredis/cluster.py
+++ b/rmtest/disposableredis/cluster.py
@@ -67,7 +67,7 @@ class Cluster(object):
                 if status.get('cluster_state') == 'ok':
                     ok += 1
             if ok == len(self.nodes):
-                print "All nodes OK!"
+                print("All nodes OK!")
                 return
 
             time.sleep(0.1)


### PR DESCRIPTION
Trival fix for this failure...

*** Error compiling '.../usr/lib/python3.6/site-packages/rmtest/disposableredis/cluster.py'...
  File "/usr/lib/python3.6/cluster.py", line 70
    print "All nodes OK!"
                        ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(print "All nodes OK!")?