### PR TITLE
Allow both python2 and python3 use with the rmtest module

### DIFF
--- a/rmtest/__init__.py
+++ b/rmtest/__init__.py
@@ -52,14 +52,17 @@ class BaseModuleTestCase(unittest.TestCase):
     def cmd(self, *args, **kwargs):
         return self.client.execute_command(*args, **kwargs)
 
-    def assertOk(self, x):
-        self.assertEqual("OK", x.decode())
+    def assertOk(self, x, msg=None):
+        self.assertEqual("OK", x.decode(), msg)
 
     def assertCmdOk(self, cmd, *args, **kwargs):
         self.assertOk(self.cmd(cmd, *args, **kwargs))
 
-    def assertExists(self, r, key):
-        self.assertTrue(r.exists(key))
+    def assertExists(self, r, key, msg=None):
+        self.assertTrue(r.exists(key), msg)
+
+    def assertNotExists(self, r, key, msg=None):
+        self.assertFalse(r.exists(key), msg)
 
     def retry_with_reload(self):
         return self.client.retry_with_rdb_reload()

--- a/rmtest/__init__.py
+++ b/rmtest/__init__.py
@@ -53,7 +53,10 @@ class BaseModuleTestCase(unittest.TestCase):
         return self.client.execute_command(*args, **kwargs)
 
     def assertOk(self, x, msg=None):
-        self.assertEqual("OK", x.decode(), msg)
+        if type(x) == type(b""):
+            self.assertEqual(b"OK", x, msg)
+        else:
+            self.assertEqual("OK", x, msg)
 
     def assertCmdOk(self, cmd, *args, **kwargs):
         self.assertOk(self.cmd(cmd, *args, **kwargs))

--- a/rmtest/__init__.py
+++ b/rmtest/__init__.py
@@ -53,7 +53,7 @@ class BaseModuleTestCase(unittest.TestCase):
         return self.client.execute_command(*args, **kwargs)
 
     def assertOk(self, x):
-        self.assertEquals("OK", x)
+        self.assertEqual("OK", x.decode())
 
     def assertCmdOk(self, cmd, *args, **kwargs):
         self.assertOk(self.cmd(cmd, *args, **kwargs))

--- a/rmtest/cluster.py
+++ b/rmtest/cluster.py
@@ -62,19 +62,26 @@ def ClusterModuleTestCase(module_path, num_nodes=3, redis_path='redis-server', f
 
         def cmd(self, *args, **kwargs):
             """
-            Execute a non-shareded command withuot selecting the right client
+            Execute a non-sharded command without selecting the right client
             """
             return self._client.execute_command(*args, **kwargs)
 
-        def assertOk(self, x):
-            self.assertEquals("OK", x)
+        def assertOk(self, x, msg=None):
+            if type(x) == type(b""):
+                self.assertEquals(b"OK", x, msg)
+            else:
+                self.assertEquals("OK", x, msg)
 
         def assertCmdOk(self, cmd, *args, **kwargs):
             self.assertOk(self.cmd(cmd, *args, **kwargs))
 
-        def assertExists(self, key):
+        def assertExists(self, key, msg=None):
             conn = self.client_for_key(key)
-            self.assertTrue(conn.exists(key))
+            self.assertTrue(conn.exists(key), msg)
+
+        def assertNotExists(self, key, msg=None):
+            conn = self.client_for_key(key)
+            self.assertFalse(conn.exists(key), msg)
 
 
         def retry_with_rdb_reload(self):


### PR DESCRIPTION
Small tweaks to allow python3 use with rmtest, addressing
an error:
- AssertionError: 'OK' != "b'OK'"

and a deprecation warning:
- DeprecationWarning: Please use assertEqual instead.

The string vs bytes issue is the main problem - causes
module tests to fail - its resolved in a both-python2-and-
python3 compatible way using decode().